### PR TITLE
Off max line length

### DIFF
--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -1,7 +1,7 @@
 [*]
     indent_style    = space
     indent_size     = 2
-    max_line_length = 0
+    max_line_length = off
 
 [*.py]
     indent_size     = 4


### PR DESCRIPTION
fixes #313

Переделал ограничение максимальной длины. Теперь нет надоедливой неправильной линии в IDE, линии в целом больше нет.