### PR TITLE
Dead fixtures check before run tests

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -14,4 +14,5 @@ lint:
 	flake8 src
 
 test:
+	cd src && pytest --dead-fixtures
 	cd src && pytest -x

--- a/{{cookiecutter.project_slug}}/dev-requirements.txt
+++ b/{{cookiecutter.project_slug}}/dev-requirements.txt
@@ -114,7 +114,7 @@ mccabe==0.6.1
     # via flake8
 mixer==7.2.0
     # via -r dev-requirements.in
-packaging==21.0
+packaging==21.2
     # via
     #   -c requirements.txt
     #   pytest

--- a/{{cookiecutter.project_slug}}/dev-requirements.txt
+++ b/{{cookiecutter.project_slug}}/dev-requirements.txt
@@ -100,7 +100,7 @@ iniconfig==1.1.1
     # via pytest
 ipython-genutils==0.2.0
     # via traitlets
-ipython==7.28.0
+ipython==7.29.0
     # via -r dev-requirements.in
 isort==5.9.3
     # via flake8-isort

--- a/{{cookiecutter.project_slug}}/dev-requirements.txt
+++ b/{{cookiecutter.project_slug}}/dev-requirements.txt
@@ -180,7 +180,7 @@ text-unidecode==1.3
     # via faker
 toml==0.10.2
     # via pytest
-traitlets==5.1.0
+traitlets==5.1.1
     # via
     #   ipython
     #   matplotlib-inline

--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -66,7 +66,7 @@ jinja2==3.0.2
     # via coreschema
 markupsafe==2.0.1
     # via jinja2
-packaging==21.0
+packaging==21.2
     # via drf-yasg
 pillow==8.4.0
     # via -r requirements.in

--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -34,7 +34,7 @@ django-ipware==3.0.7
     # via -r requirements.in
 django-split-settings==1.1.0
     # via -r requirements.in
-django-storages==1.12.2
+django-storages==1.12.3
     # via -r requirements.in
 django==3.2.8
     # via

--- a/{{cookiecutter.project_slug}}/src/app/fixtures/__init__.py
+++ b/{{cookiecutter.project_slug}}/src/app/fixtures/__init__.py
@@ -1,5 +1,4 @@
 from app.fixtures.api import as_anon
-from app.fixtures.api import as_staff
 from app.fixtures.api import as_user
 from app.fixtures.factory import factory
 from app.fixtures.image import uploaded_image
@@ -8,7 +7,6 @@ from app.fixtures.media import _temporary_media
 __all__ = [
     'as_anon',
     'as_user',
-    'as_staff',
     'factory',
     'uploaded_image',
     '_temporary_media',

--- a/{{cookiecutter.project_slug}}/src/app/fixtures/api.py
+++ b/{{cookiecutter.project_slug}}/src/app/fixtures/api.py
@@ -11,8 +11,3 @@ def as_anon():
 @pytest.fixture
 def as_user(user):
     return ApiClient(user=user)
-
-
-@pytest.fixture
-def as_staff(staff):
-    return ApiClient(user=staff)

--- a/{{cookiecutter.project_slug}}/src/users/fixtures.py
+++ b/{{cookiecutter.project_slug}}/src/users/fixtures.py
@@ -2,15 +2,5 @@ import pytest
 
 
 @pytest.fixture
-def anon(factory):
-    return factory.anon()
-
-
-@pytest.fixture
 def user(factory):
     return factory.user()
-
-
-@pytest.fixture
-def staff(factory):
-    return factory.user(is_staff=True)


### PR DESCRIPTION
Добавил запуск --dead-fixtures. Данная опция не запускает тесты, а только делает проверку на фикстуры.
Закрывает https://github.com/fandsdev/django/issues/352