### PR TITLE
Bump python to 3.10

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -13,7 +13,7 @@ Django user model is located in the separate `users` app.
 Also, feel free to add as much django apps as you want.
 
 ## Installing on a local machine
-This project requires python 3.8. Deps are managed by [pip-tools](https://github.com/jazzband/pip-tools)
+This project requires python 3.10. Deps are managed by [pip-tools](https://github.com/jazzband/pip-tools)
 
 Install requirements:
 

--- a/{{cookiecutter.project_slug}}/src/mypy.ini
+++ b/{{cookiecutter.project_slug}}/src/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 files = .
 namespace_packages = on
 explicit_package_bases = on

--- a/{{cookiecutter.project_slug}}/src/pytest.ini
+++ b/{{cookiecutter.project_slug}}/src/pytest.ini
@@ -8,6 +8,7 @@ markers =
 filterwarnings =
   ignore:django.conf.urls.url\(\) is deprecated
   ignore:.*You can remove default_app_config
+  ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning:pytest_freezegun:17
 
 env =
   CI=1


### PR DESCRIPTION
Обновил в документации версию питона, добавил игнор в тесты. https://github.com/fandsdev/django/issues/521


Как оказалось, зависимости уже были сформированы через python3.10. 

proof:
```
============================= test session starts ==============================
platform darwin -- Python 3.10.5, pytest-7.1.1, pluggy-1.0.0
django: settings: app.settings (from ini)
Using --randomly-seed=2904119868
rootdir: /Users/denissurkov/Work/fands/django-template/f/src, configfile: pytest.ini
plugins: freezegun-0.4.2, deadfixtures-2.2.1, env-0.6.2, mock-3.7.0, Faker-8.16.0, django-4.5.2, randomly-3.11.0
collected 23 items

app/tests/test_health.py .                                               [  4%]
a12n/tests/jwt_views/test_refresh_jwt_token.py ......                    [ 30%]
users/tests/test_password_hashing.py .                                   [ 34%]
app/tests/test_remote_addr_midlleware.py .                               [ 39%]
users/tests/test_whoami.py ..                                            [ 47%]
a12n/tests/jwt_views/test_obtain_jwt_view.py .......                     [ 78%]
app/tests/testing/factory/test_registry.py ..                            [ 86%]
app/tests/testing/factory/test_factory.py ...                            [100%]

============================== 23 passed in 9.54s ==============================
```

