### PR TITLE
default_app_config setting is removed from the template as deprecated

### DIFF
--- a/{{cookiecutter.project_slug}}/src/.django-app-template/__init__.py-tpl
+++ b/{{cookiecutter.project_slug}}/src/.django-app-template/__init__.py-tpl
@@ -1,1 +1,0 @@
-default_app_config = '{{ app_name }}.apps.{{ camel_case_app_name }}Config'


### PR DESCRIPTION
Настройка default_app_config стала [deprecated](https://docs.djangoproject.com/en/4.1/releases/3.2/#automatic-appconfig-discovery) начиная с django 3.2, из-за нее сыпятся ворнинги:

> RemovedInDjango41Warning: 'some_app' defines default_app_config = 'some_app.apps.SomeAppConfig'. However, Django's automatic detection did not find this configuration. You should move the default config class to the apps submodule of your application and, if this module defines several config classes, mark the default one with default = True.
>     app_config = AppConfig.create(entry)