### PR TITLE
Annotate for ordering filterset mixin

### DIFF
--- a/{{cookiecutter.project_slug}}/src/app/api/filterset_mixins.py
+++ b/{{cookiecutter.project_slug}}/src/app/api/filterset_mixins.py
@@ -1,0 +1,54 @@
+from typing import Union
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import QuerySet
+from django.http import QueryDict
+
+
+class AnnotateForOrderingMixin:
+    """Annotate queryset for ordering when it needs to.
+
+    It is useful when heavy annotation required for optional and rare used ordering.
+
+    N.B.:
+        1. Default ordering filter name: `ordering`.
+        You can set it explicitly with `ordering_filter_name` attribute
+
+        2. To annotate queryset before ordering by `param_name` declare
+        `annotate_for_ordering_by_{param_name}()` method. Examples could be found in tests.
+    """
+
+    ordering_filter_name: str = 'ordering'
+
+    def filter_queryset(self, queryset: QuerySet) -> QuerySet:
+        self.validate_ordering_filter_name()
+        queryset = self.annotate_for_ordering(queryset, self.get_ordering_params(self.data))  # type: ignore
+
+        return super().filter_queryset(queryset)  # type: ignore
+
+    def validate_ordering_filter_name(self) -> None:
+        if not self.declared_filters.get(self.ordering_filter_name):  # type: ignore
+            raise ImproperlyConfigured(
+                f'Ordering filter \"{self.ordering_filter_name}\" was not found. '
+                'Set filter with default name `ordering` or use `ordering_filter_name` attr.',
+            )
+
+    def get_ordering_params(self, data: Union[QueryDict, None]) -> set[str]:
+        if data is None:
+            return set()
+
+        request_ordering_query = data.get(self.ordering_filter_name)
+        if not request_ordering_query:
+            return set()
+
+        return {
+            param[1:] if param.startswith('-') else param
+            for param in request_ordering_query.split(',')
+        }
+
+    def annotate_for_ordering(self, queryset: QuerySet, ordering_params: set[str]) -> QuerySet:
+        for param in ordering_params:
+            method = getattr(self, f'annotate_for_ordering_by_{param}', None)
+            queryset = method(queryset) if method else queryset
+
+        return queryset

--- a/{{cookiecutter.project_slug}}/src/app/api/filterset_mixins.py
+++ b/{{cookiecutter.project_slug}}/src/app/api/filterset_mixins.py
@@ -8,14 +8,26 @@ from django.http import QueryDict
 class AnnotateForOrderingMixin:
     """Annotate queryset for ordering when it needs to.
 
-    It is useful when heavy annotation required for optional and rare used ordering.
+    It helps to avoid annotations (that may be heavy) for ordering filter in viewset's `get_queryset`.
+    Instead of that you can declare `annotate_for_ordering_{ordering_param_name}` methods in FilterSet
+    class: the annotation will happen only when the ordering filter's param is used in the request's query params.
+
+    Example of use (see tests for more):
+        class SomeFilterSet(AnnotateForOrderingMixin, filters.FilterSet):
+            ordering = filters.OrderingFilter(
+                fields=('score'),  <-- ordering param that requires annotation
+            )
+
+            def annotate_for_ordering_by_score(self, queryset):  <-- will be called when `?ordering=score` in request
+                return queryset.do_heavy_annotation()
 
     N.B.:
         1. Default ordering filter name: `ordering`.
         You can set it explicitly with `ordering_filter_name` attribute
 
-        2. To annotate queryset before ordering by `param_name` declare
-        `annotate_for_ordering_by_{param_name}()` method. Examples could be found in tests.
+        2. To annotate queryset for ordering by `param_name` declare
+            `def annotate_for_ordering_by_{param_name}(self, queryset: Queryset) -> Queryset:`
+        method.
     """
 
     ordering_filter_name: str = 'ordering'

--- a/{{cookiecutter.project_slug}}/src/app/tests/api/test_annotate_for_ordering_filterset_mixin.py
+++ b/{{cookiecutter.project_slug}}/src/app/tests/api/test_annotate_for_ordering_filterset_mixin.py
@@ -1,0 +1,139 @@
+import pytest
+
+from django_filters import rest_framework as filters
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+
+from app.api.filterset_mixins import AnnotateForOrderingMixin
+
+
+class DummyQuerySet(models.QuerySet):
+    def do_heavy_annotation(self):
+        return self
+
+    def order_by(self, *field_names):
+        return self
+
+
+class DummyModel(models.Model):
+    objects = DummyQuerySet.as_manager()
+
+    class Meta:
+        app_label = 'dummy_app'
+
+    def __str__(self):
+        pass
+
+
+class FilterSetDeclaredOrdering(AnnotateForOrderingMixin, filters.FilterSet):
+    ordering = filters.OrderingFilter(
+        fields=(
+            'color',  # common model field
+            'score',  # require heavy annotation
+        ),
+    )
+
+    def annotate_for_ordering_by_score(self, queryset):  # should be called for ordering by `score` field
+        return queryset.do_heavy_annotation()
+
+
+class FilterSetNotDeclaredOrdering(AnnotateForOrderingMixin, filters.FilterSet):
+    pass
+
+
+class FilterSetDeclaredNonDefaultOrdering(AnnotateForOrderingMixin, filters.FilterSet):
+    ordering_filter_name = 'non_default_ordering'
+
+    non_default_ordering = filters.OrderingFilter(
+        fields=(
+            'color',
+            'score',
+        ),
+    )
+
+    def annotate_for_ordering_by_color(self, queryset):  # should be called for ordering by `color` field
+        return queryset.do_heavy_annotation()
+
+
+@pytest.fixture
+def queryset():
+    return DummyModel.objects.none()  # none() is enough for tests and not trying to access to db
+
+
+@pytest.fixture
+def get_filterset(queryset):
+    return (
+        lambda _data, _queryset=queryset, filterset_class=FilterSetDeclaredOrdering:
+        filterset_class(data=_data, queryset=_queryset)
+    )
+
+
+@pytest.fixture
+def spy_heavy_annotation(mocker):
+    return mocker.spy(DummyQuerySet, 'do_heavy_annotation')
+
+
+@pytest.fixture
+def spy_order_by(mocker):
+    return mocker.spy(DummyQuerySet, 'order_by')
+
+
+def test_queryset_annotation_called_while_ordering_by_field_with_annotate_for_method(get_filterset, spy_heavy_annotation):
+    data = {
+        'ordering': 'score',
+    }
+
+    get_filterset(data).qs  # act
+
+    spy_heavy_annotation.assert_called_once()
+
+
+def test_annotate_for_ordering_not_called_common_field(get_filterset, spy_heavy_annotation):
+    data = {
+        'ordering': 'color',
+    }
+
+    get_filterset(data).qs  # act
+
+    spy_heavy_annotation.assert_not_called()
+
+
+def test_queryset_order_by_called_with_args(get_filterset, spy_heavy_annotation, spy_order_by):
+    data = {
+        'ordering': 'score,-color',
+    }
+
+    get_filterset(data).qs  # act
+
+    spy_heavy_annotation.assert_called_once()
+    order_by_field_names = spy_order_by.call_args.args[1:]
+    assert order_by_field_names == ('score', '-color')
+
+
+def test_empty_ordering_request_data_not_call_annotation_and_order_by(get_filterset, spy_heavy_annotation, spy_order_by):
+    data = None
+
+    get_filterset(data).qs  # act
+
+    spy_heavy_annotation.assert_not_called()
+    spy_order_by.assert_not_called()
+
+
+def test_improperly_configured_if_ordering_filter_not_declared(get_filterset, queryset):
+    data = {
+        'ordering': 'score',
+    }
+
+    with pytest.raises(ImproperlyConfigured, match='was not found'):
+        get_filterset(data, queryset, FilterSetNotDeclaredOrdering).qs
+
+
+def test_non_default_ordering_field_call_annotation(get_filterset, queryset, spy_heavy_annotation):
+    data = {
+        'non_default_ordering': 'color',
+    }
+
+    get_filterset(data, queryset, FilterSetDeclaredNonDefaultOrdering).qs  # act
+
+    spy_heavy_annotation.assert_called_once()


### PR DESCRIPTION
Для чего: делать аннотоции для сортировки только когда они нужны.
Бывает полезно если какая-то аннотация тяжелая и не хочется добавлять в метод `get_queryset` вьюсета.

Сделали и используем в вебиуме.