### PR TITLE
Fix circle ci and Dockerfile update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 orbs:
-  docker: circleci/docker@1.7.0
+  docker: circleci/docker@2.4.0
 
 jobs:
   build:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
 
     steps:
       - checkout
@@ -34,7 +34,7 @@ jobs:
 
   coverage:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
     steps:
       - checkout
       - attach_workspace:
@@ -73,5 +73,6 @@ workflows:
           image: f213/django
           path: testproject/django
           docker-context: testproject/django
+          extra_build_args: '--build-arg PYTHON_VERSION=3.11'
           deploy: false
           attach-at: .

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION
-FROM python:${PYTHON_VERSION}-slim-bullseye
+FROM python:${PYTHON_VERSION}-slim-bookworm
 LABEL maintainer="fedor@borshev.com"
 
 LABEL com.datadoghq.ad.logs='[{"source": "uwsgi", "service": "django"}]'
@@ -9,9 +9,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ENV STATIC_ROOT /static
 
-ENV _UWSGI_VERSION 2.0.20
+ENV _UWSGI_VERSION 2.0.23
 
-RUN echo deb http://deb.debian.org/debian bullseye contrib non-free > /etc/apt/sources.list.d/debian-contrib.list \
+RUN echo deb http://deb.debian.org/debian bookworm contrib non-free > /etc/apt/sources.list.d/debian-contrib.list \
   && apt update \
   && apt --no-install-recommends install -y gettext locales-all wget \
   imagemagick tzdata wait-for-it build-essential \


### PR DESCRIPTION
1. Circle: update orb version, cause the previous one deprecated
2. Circle: explicitly set python 3.11 version to use for test and build
3. Dockerfile: update debian version to last one
4. Dockerfile: update UWSGI cause previous doesn't support python 3.11