### PR TITLE
fix startapp management cmd

### DIFF
--- a/{{ cookiecutter.name }}/src/app/apps.py
+++ b/{{ cookiecutter.name }}/src/app/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class AppConfig(AppConfig):
+    name = "app"

--- a/{{ cookiecutter.name }}/src/app/apps.py
+++ b/{{ cookiecutter.name }}/src/app/apps.py
@@ -1,5 +1,5 @@
-from django.apps import AppConfig
+from django.apps import AppConfig as DjangoAppConfig
 
 
-class AppConfig(AppConfig):
+class AppConfig(DjangoAppConfig):
     name = "app"

--- a/{{ cookiecutter.name }}/src/app/conf/installed_apps.py
+++ b/{{ cookiecutter.name }}/src/app/conf/installed_apps.py
@@ -2,6 +2,7 @@
 
 APPS = [
     "a12n",
+    "app",
     "users",
 ]
 

--- a/{{ cookiecutter.name }}/src/app/management/commands/startapp.py
+++ b/{{ cookiecutter.name }}/src/app/management/commands/startapp.py
@@ -1,5 +1,3 @@
-from os import path
-
 from django.conf import settings
 from django.core.management.commands.startapp import Command as BaseCommand
 
@@ -8,7 +6,18 @@ class Command(BaseCommand):
     """Set custom template for all newly generated apps"""
 
     def handle(self, **options):
+        if "directory" not in options or options["directory"] is None:
+            directory = settings.BASE_DIR.parent / options["name"]
+
+            directory.mkdir(exist_ok=True)
+
+            options["directory"] = str(directory)
+
         if "template" not in options or options["template"] is None:
-            options["template"] = path.join(settings.BASE_DIR, ".django-app-template")
+            template = settings.BASE_DIR.parent / ".django-app-template"
+
+            options["template"] = str(template)
 
         super().handle(**options)
+
+    def validate_name(self, *args, **kwargs): ...


### PR DESCRIPTION
Контекст: https://github.com/fandsdev/django/pull/567#issuecomment-2132244295.

Я отключила валидацию названия приложения, потому что если в `options` задана директория, она [должна существовать](https://github.com/django/django/blob/main/django/core/management/templates.py#L107). Но если директория существует, то [валидация названия](https://github.com/django/django/blob/main/django/core/management/templates.py#L279) не проходит. Не понимаю, это в джанге баг или я что-то делаю не так.

Этот MR делает так, чтобы при запуске `startapp`-команды использовалась кастомная команда и с кастомным шаблоном (использовалась джанговская, т. к. `app`-папка не была зарегистрирована как приложение), и создаёт приложение в папке `src`, а не рядом с ней:

https://github.com/fandsdev/django/assets/67327570/50385dcf-1cfb-4174-ab51-d07cf12f2fea

