### PR TITLE
Changing isort, black and poetry configuration

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -8,9 +8,6 @@ poetry install
 poetry run python src/manage.py collectstatic
 poetry run python src/manage.py startapp some_app
 poetry run python src/manage.py makemigrations -n "initial"
-
-poetry run isort src/users/migrations/0001_initial.py
-
 poetry run python src/manage.py migrate
 
 make test

--- a/{{ cookiecutter.name }}/poetry.toml
+++ b/{{ cookiecutter.name }}/poetry.toml
@@ -1,0 +1,2 @@
+[virtualenvs]
+in-project = true

--- a/{{ cookiecutter.name }}/pyproject.toml
+++ b/{{ cookiecutter.name }}/pyproject.toml
@@ -70,6 +70,11 @@ types-freezegun = "^1.1.10"
 types-pillow = "^10.2.0.20240520"
 
 [tool.black]
+exclude = '''
+/(
+  | migrations
+)/
+'''
 line_length = 160
 
 [tool.flake8]
@@ -78,7 +83,7 @@ ignore = [
     "E203",  # whitespace before ':'
     "E265",  # block comment should start with '#'
     "E501",  # line too long ({} > {} characters)
-    "E704",  # Multiple statements on one line (def)
+    "E704",  # multiple statements on one line (def)
     "F811",  # redefinition of unused name from line {}
     "PT001",  # use @pytest.fixture() over @pytest.fixture
     "SIM102",  # use a single if-statement instead of nested if-statements
@@ -90,6 +95,9 @@ inline-quotes = '"'
 include_trailing_comma = true
 line_length = 160
 multi_line_output = 3
+skip = [
+    "migrations",
+]
 src_paths = ["src", "tests"]
 use_parentheses = true
 


### PR DESCRIPTION
- excluding the contents of the "migrations" folder from formatting and sorting
- add poetry.toml to force local venv creation (no one needs more than one virtual environment for a Django project anyway)