### PR TITLE
Introduce ruff

### DIFF
--- a/{{ cookiecutter.name }}/Makefile
+++ b/{{ cookiecutter.name }}/Makefile
@@ -3,18 +3,16 @@ SIMULTANEOS_TEST_JOBS = 4
 manage = poetry run python src/manage.py
 
 fmt:
-	poetry run autoflake --in-place --remove-all-unused-imports --recursive src
-	poetry run isort src
-	poetry run black src
+	poetry run ruff check src --fix --unsafe-fixes
+	poetry run ruff format src
 	poetry run toml-sort pyproject.toml
 
 lint:
 	$(manage) check
 	$(manage) makemigrations --check --dry-run --no-input
 
-	poetry run isort --check-only src
-	poetry run black --check src
-	poetry run flake8 src
+	poetry run ruff check src
+	poetry run ruff format --check src
 	poetry run mypy src
 	poetry run toml-sort pyproject.toml --check
 	poetry run pymarkdown scan README.md

--- a/{{ cookiecutter.name }}/README.md
+++ b/{{ cookiecutter.name }}/README.md
@@ -46,7 +46,7 @@ make test  # run tests
 ### Style
 
 * Obey [django's style guide](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#model-style).
-* Configure your IDE to use [flake8](https://pypi.python.org/pypi/flake8) for checking your python code. To run our linters manualy, do `make lint`.
+* Configure your IDE to use [ruff](https://pypi.org/project/ruff) for checking your python code. To run our linters manualy, do `make lint`.
 * Prefer English over your native language in comments and commit messages.
 * Commit messages should contain the unique id of issue they are linked to (refs #100500).
 * Every model, service and model method should have a docstring.

--- a/{{ cookiecutter.name }}/README.md
+++ b/{{ cookiecutter.name }}/README.md
@@ -46,7 +46,7 @@ make test  # run tests
 ### Style
 
 * Obey [django's style guide](https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/coding-style/#model-style).
-* Configure your IDE to use [ruff](https://pypi.org/project/ruff) for checking your python code. To run our linters manualy, do `make lint`.
+* Configure your IDE to use [ruff](https://pypi.org/project/ruff) for checking your Python code. To run our linters manually, do `make lint`. Feel free to [adjust](https://docs.astral.sh/ruff/configuration/) ruff [rules](https://docs.astral.sh/ruff/rules/) in `pyproject.toml` section `tool.ruff.lint` for your needs.
 * Prefer English over your native language in comments and commit messages.
 * Commit messages should contain the unique id of issue they are linked to (refs #100500).
 * Every model, service and model method should have a docstring.

--- a/{{ cookiecutter.name }}/pyproject.toml
+++ b/{{ cookiecutter.name }}/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core"]
-requires-python = ">=3.11,<3.12"
+
+[project]
+requires-python = "~=3.11"
 
 [tool.poetry]
 authors = ["Fedor Borshev <fedor@borshev.com>"]
@@ -29,6 +31,7 @@ drf-jwt = "^1.19.2"
 drf-spectacular = {extras = ["sidecar"], version = "^0.27.2"}
 pillow = "^10.1.0"
 psycopg2-binary = "^2.9.9"
+python = "~3.11"
 redis = "^5.0.7"
 sentry-sdk = "^2.11.0"
 whitenoise = "^6.7.0"
@@ -91,10 +94,7 @@ ignore = [
     "ARG005",  # unused lambda argument: `{}`
     "B018",  # found useless expression. Either assign it to a variable or remove it
     "B904",  # within an `except` clause, raise exceptions with [...]
-    "B904",  # use `raise from` to specify exception cause
     "C408",  # unnecessary `dict` call (rewrite as a literal)
-    "COM812",  # trailing comma missing
-    "COM819",  # trailing comma prohibited
     "D100",  # missing docstring in public module
     "D101",  # missing docstring in public class
     "D102",  # missing docstring in public method
@@ -115,18 +115,15 @@ ignore = [
     "D401",  # first line of docstring should be in imperative mood: "{}"
     "D404",  # first word of the docstring should not be "This"
     "D415",  # first line should end with a period, question mark, or exclamation point
-    "DJ007",  # do not use `__all__` with `ModelForm`, use `fields` instead
     "DTZ001",  # the use of `datetime.datetime()` without `tzinfo` argument is not allowed
     "E501",  # line too long ({} > {})
     "EM101",  # exception must not use a string literal, assign to variable first
     "EM102",  # expection must not use an f-string literal, assign to variable first
-    "F811",  # redefinition of unused `{}` from line {}
     "FBT001",  # boolean-typed position argument in function definition
     "FBT002",  # boolean default position argument in function definition
     "FBT003",  # boolean positional value in function call
     "INP001",  # file `{}` is part of an implicit namespace package. Add an `__init__.py`
     "INT001",  # f-string is resolved before function call; consider `_("string %s") % arg`
-    "ISC001",  # implicitly concatenated string literals on one line
     "N802",  # function name `{}` should be lowercase
     "N803",  # argument name `{}` should be lowercase
     "N804",  # first argument of a class method should be named `cls`
@@ -137,42 +134,18 @@ ignore = [
     "PERF401",  # use a list comprehension to create a transformed list
     "PGH003",  # use specific rule codes when ignoring type issues
     "PGH004",  # use specific rule codes when using `noqa`
-    "PLR0913",  # too many arguments in function definition ({} > {})
-    "PLR2004",  # magic value used in comparison, consider replacing {} with constant variable
-    "PLR5501",  # use `elif` instead of `else` then `if` to reduce indentation
-    "PLW0603",  # using the global statement to update `{}` is discouraged
-    "PLW2901",  # `for` loop variable `{}` overwritten by assignment target
     "PT001",  # use `@pytest.fixture()` over `@pytest.fixture`
-    "PT006",  # wrong name(s) type in `@pytest.mark.parametrize`, expected `{}`
-    "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator
-    "PTH119",  # `os.path.basename()` should be replaced by `Path.name`
-    "PTH120",  # `os.path.dirname()` should be replaced by `Path.parent`
-    "PTH122",  # `os.path.splitext()` should be replaced by `Path.suffix`, [...]
-    "PTH123",  # `open()` should be replaced by `Path.open()`
-    "Q000",  # single quotes found but double quotes preferred
     "RET501",  # do not explicitly `return None` in function if it is the only possible return value
     "RET502",  # do not implicitly `return None` in function able to return non-`None` value
     "RET503",  # missing explicit `return` at the end of function able to return non-`None` value
-    "RET504",  # unnecessary assignment to `{}` before `return` statement
-    "RET505",  # unnecessary `else` after `return` statement
-    "RSE102",  # unnecessary parentheses on raised exception
-    "RUF001",  # string contains ambiguous `{}` [...]
-    "RUF002",  # docstring contains ambiguous `{}` [...]
-    "RUF005",  # consider iterable unpacking instead of concatenation"
-    "RUF009",  # do not perform function call `{}` in dataclass defaults
     "RUF012",  # mutable class attributes should be annotated with `typing.ClassVar`
     "RUF015",  # prefer next({iterable}) over single element slice
-    "RUF100",  # unused `noqa` directive (unknown: `{}`)
     "S101",  # use of `assert` detected
-    "S105",  # possible hardcoded password assigned to: "{}"
-    "S106",  # possible hardcoded password assigned to argument: "{}"
-    "S308",  # use of `mark_safe` may expose cross-site scripting vulnerabilities
     "S311",  # standart pseudo-random generators are not suitable for cryptographic purposes
     "S324",  # probable use of insecure hash functions in `{}`: `{}`
     "SIM102",  # use a single `if` statement instead of nested `if` statements
     "SIM108",  # use ternary operator `{}` instead of `if`-`else`-block
-    "SIM300",  # yoda conditions are discouraged, use `{}` instead
-    "SLF001",  # private member accessed: `{}`
+    "SIM113",  # use enumerate instead of manually incrementing a counter
     "TC001",  # move application import `{}` into a type-checking block
     "TC002",  # move third-party import `{}` into a type-checking block
     "TC003",  # move standart library import `{}` into a type-checking block
@@ -207,6 +180,7 @@ lines-after-imports = 2
 "*/tests/*" = [
     "ANN",  # flake8-annotations
     "ARG001",
+    "PLR2004",
 ]
 "src/app/conf/*" = [
     "ANN",  # flake8-annotations
@@ -214,6 +188,7 @@ lines-after-imports = 2
 "src/app/testing/*" = [
     "ANN",  # flake8-annotations
     "ARG001",
+    "PLR2004",
 ]
 
 [tool.tomlsort]

--- a/{{ cookiecutter.name }}/pyproject.toml
+++ b/{{ cookiecutter.name }}/pyproject.toml
@@ -34,27 +34,11 @@ sentry-sdk = "^2.11.0"
 whitenoise = "^6.7.0"
 
 [tool.poetry.group.dev.dependencies]
-autoflake = "^2.2.1"
-black = "^24.4.2"
 django-stubs = "^5.1.1"
 djangorestframework-stubs = "^3.15.0"
 dotenv-linter = "^0.5.0"
-flake8-absolute-import = "^1.0.0.2"
-flake8-bugbear = "^24.4.26"
-flake8-cognitive-complexity = "^0.1.0"
-flake8-django = "^1.4"
-flake8-eradicate = "^1.5.0"
-flake8-fixme = "^1.1.1"
-flake8-pep3101 = "^2.1.0"
-flake8-pie = "^0.16.0"
-flake8-print = "^5.0.0"
-flake8-printf-formatting = "^1.1.2"
-flake8-pyproject = "^1.2.3"
-flake8-variables-names = "^0.0.6"
-flake8-walrus = "^1.2.0"
 freezegun = "^1.5.1"
 ipython = "^8.26.0"
-isort = "^5.12.0"
 jedi = "^0.19.1"
 mixer = {extras = ["django"], version = "^7.2.2"}
 mypy = "^1.11.0"
@@ -66,41 +50,10 @@ pytest-freezer = "^0.4.8"
 pytest-mock = "^3.12.0"
 pytest-randomly = "^3.15.0"
 pytest-xdist = "^3.6.1"
+ruff = "^0.8.0"
 toml-sort = "^0.23.1"
 types-freezegun = "^1.1.10"
 types-pillow = "^10.2.0.20240520"
-
-[tool.black]
-exclude = '''
-/(
-  | migrations
-)/
-'''
-line_length = 160
-
-[tool.flake8]
-exclude = ["__pycache__", "migrations"]
-ignore = [
-    "E203",  # whitespace before ':'
-    "E265",  # block comment should start with '#'
-    "E501",  # line too long ({} > {} characters)
-    "E704",  # multiple statements on one line (def)
-    "F811",  # redefinition of unused name from line {}
-    "PT001",  # use @pytest.fixture() over @pytest.fixture
-    "SIM102",  # use a single if-statement instead of nested if-statements
-    "SIM113",  # use enumerate instead of manually incrementing a counter
-]
-inline-quotes = '"'
-
-[tool.isort]
-include_trailing_comma = true
-line_length = 160
-multi_line_output = 3
-skip = [
-    "migrations",
-]
-src_paths = ["src", "tests"]
-use_parentheses = true
 
 [tool.pymarkdown.plugins.md013]
 enabled = false
@@ -122,6 +75,147 @@ filterwarnings = [
 ]
 python_files = ["test*.py"]
 pythonpath = ". src"
+
+[tool.ruff]
+exclude = ["__pycache__", "migrations"]
+line-length = 160
+src = ["src"]
+target-version = "py311"
+
+[tool.ruff.lint]
+ignore = [
+    "A001",  # variable `{}` is shadowing a Python builtin
+    "A002",  # argument `{}` is shadowing a Python builtin
+    "A003",  # class attribute `{}` is shadowing a Python builtin
+    "ANN401",  # dynamically typed expressions (typing.Any) are disallowed in `{}`
+    "ARG002",  # unused method argument: `{}`
+    "ARG005",  # unused lambda argument: `{}`
+    "B018",  # found useless expression. Either assign it to a variable or remove it
+    "B904",  # within an `except` clause, raise exceptions with [...]
+    "B904",  # use `raise from` to specify exception cause
+    "C408",  # unnecessary `dict` call (rewrite as a literal)
+    "COM812",  # trailing comma missing
+    "COM819",  # trailing comma prohibited
+    "D100",  # missing docstring in public module
+    "D101",  # missing docstring in public class
+    "D102",  # missing docstring in public method
+    "D103",  # missing docstring in public function
+    "D104",  # missing docstring in public package
+    "D105",  # missing docstring in magic method
+    "D106",  # missing docstring in public nested class
+    "D107",  # missing docstring in `__init__`
+    "D200",  # one-line docstring should fit on one line
+    "D202",  # no blank lines allowed after function docstring (found {})
+    "D203",  # 1 blank line required before class docstring
+    "D205",  # 1 blank line required between summary line and description
+    "D209",  # multi-line docstring closing quotes should be on a separate line
+    "D210",  # no whitespaces allowed surrounding docstring text
+    "D212",  # multi-line docstring summary should start at the first line
+    "D213",  # multi-line docstring summary should start at the second line
+    "D400",  # first line should end with a period
+    "D401",  # first line of docstring should be in imperative mood: "{}"
+    "D404",  # first word of the docstring should not be "This"
+    "D415",  # first line should end with a period, question mark, or exclamation point
+    "DJ007",  # do not use `__all__` with `ModelForm`, use `fields` instead
+    "DTZ001",  # the use of `datetime.datetime()` without `tzinfo` argument is not allowed
+    "E501",  # line too long ({} > {})
+    "EM101",  # exception must not use a string literal, assign to variable first
+    "EM102",  # expection must not use an f-string literal, assign to variable first
+    "F811",  # redefinition of unused `{}` from line {}
+    "FBT001",  # boolean-typed position argument in function definition
+    "FBT002",  # boolean default position argument in function definition
+    "FBT003",  # boolean positional value in function call
+    "INP001",  # file `{}` is part of an implicit namespace package. Add an `__init__.py`
+    "INT001",  # f-string is resolved before function call; consider `_("string %s") % arg`
+    "ISC001",  # implicitly concatenated string literals on one line
+    "N802",  # function name `{}` should be lowercase
+    "N803",  # argument name `{}` should be lowercase
+    "N804",  # first argument of a class method should be named `cls`
+    "N806",  # variable `{}` in function should be lowercase
+    "N812",  # lowercase `{}` imported as non-lowercase `{}`
+    "N818",  # exception name `{}` should be named with an Error suffix
+    "N999",  # invalid module name: '{}'
+    "PERF401",  # use a list comprehension to create a transformed list
+    "PGH003",  # use specific rule codes when ignoring type issues
+    "PGH004",  # use specific rule codes when using `noqa`
+    "PLR0913",  # too many arguments in function definition ({} > {})
+    "PLR2004",  # magic value used in comparison, consider replacing {} with constant variable
+    "PLR5501",  # use `elif` instead of `else` then `if` to reduce indentation
+    "PLW0603",  # using the global statement to update `{}` is discouraged
+    "PLW2901",  # `for` loop variable `{}` overwritten by assignment target
+    "PT001",  # use `@pytest.fixture()` over `@pytest.fixture`
+    "PT006",  # wrong name(s) type in `@pytest.mark.parametrize`, expected `{}`
+    "PTH118",  # `os.path.join()` should be replaced by `Path` with `/` operator
+    "PTH119",  # `os.path.basename()` should be replaced by `Path.name`
+    "PTH120",  # `os.path.dirname()` should be replaced by `Path.parent`
+    "PTH122",  # `os.path.splitext()` should be replaced by `Path.suffix`, [...]
+    "PTH123",  # `open()` should be replaced by `Path.open()`
+    "Q000",  # single quotes found but double quotes preferred
+    "RET501",  # do not explicitly `return None` in function if it is the only possible return value
+    "RET502",  # do not implicitly `return None` in function able to return non-`None` value
+    "RET503",  # missing explicit `return` at the end of function able to return non-`None` value
+    "RET504",  # unnecessary assignment to `{}` before `return` statement
+    "RET505",  # unnecessary `else` after `return` statement
+    "RSE102",  # unnecessary parentheses on raised exception
+    "RUF001",  # string contains ambiguous `{}` [...]
+    "RUF002",  # docstring contains ambiguous `{}` [...]
+    "RUF005",  # consider iterable unpacking instead of concatenation"
+    "RUF009",  # do not perform function call `{}` in dataclass defaults
+    "RUF012",  # mutable class attributes should be annotated with `typing.ClassVar`
+    "RUF015",  # prefer next({iterable}) over single element slice
+    "RUF100",  # unused `noqa` directive (unknown: `{}`)
+    "S101",  # use of `assert` detected
+    "S105",  # possible hardcoded password assigned to: "{}"
+    "S106",  # possible hardcoded password assigned to argument: "{}"
+    "S308",  # use of `mark_safe` may expose cross-site scripting vulnerabilities
+    "S311",  # standart pseudo-random generators are not suitable for cryptographic purposes
+    "S324",  # probable use of insecure hash functions in `{}`: `{}`
+    "SIM102",  # use a single `if` statement instead of nested `if` statements
+    "SIM108",  # use ternary operator `{}` instead of `if`-`else`-block
+    "SIM300",  # yoda conditions are discouraged, use `{}` instead
+    "SLF001",  # private member accessed: `{}`
+    "TC001",  # move application import `{}` into a type-checking block
+    "TC002",  # move third-party import `{}` into a type-checking block
+    "TC003",  # move standart library import `{}` into a type-checking block
+    "TRY003",  # avoid specifying long messages outside the exception class
+    "TRY300",  # consider moving this statement to an `else` block
+]
+select = ["ALL"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["src"]
+lines-after-imports = 2
+
+[tool.ruff.lint.per-file-ignores]
+"*/factory.py" = [
+    "ANN",  # flake8-annotations
+    "ARG001",
+]
+"*/fixtures.py" = [
+    "ANN",  # flake8-annotations
+    "ARG001",
+]
+"*/management/*" = [
+    "ANN",  # flake8-annotations
+]
+"*/migrations/*" = [
+    "ANN",  # flake8-annotations
+]
+"*/tests/*" = [
+    "ANN",  # flake8-annotations
+    "ARG001",
+]
+"src/app/conf/*" = [
+    "ANN",  # flake8-annotations
+]
+"src/app/testing/*" = [
+    "ANN",  # flake8-annotations
+    "ARG001",
+]
 
 [tool.tomlsort]
 all = true

--- a/{{ cookiecutter.name }}/pyproject.toml
+++ b/{{ cookiecutter.name }}/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 build-backend = "poetry.core.masonry.api"
 requires = ["poetry-core"]
+requires-python = ">=3.11,<3.12"
 
 [tool.poetry]
 authors = ["Fedor Borshev <fedor@borshev.com>"]
@@ -28,7 +29,6 @@ drf-jwt = "^1.19.2"
 drf-spectacular = {extras = ["sidecar"], version = "^0.27.2"}
 pillow = "^10.1.0"
 psycopg2-binary = "^2.9.9"
-python = "~3.11"
 redis = "^5.0.7"
 sentry-sdk = "^2.11.0"
 whitenoise = "^6.7.0"
@@ -80,7 +80,6 @@ pythonpath = ". src"
 exclude = ["__pycache__", "migrations"]
 line-length = 160
 src = ["src"]
-target-version = "py311"
 
 [tool.ruff.lint]
 ignore = [

--- a/{{ cookiecutter.name }}/src/.django-app-template/admin/__init__.py-tpl
+++ b/{{ cookiecutter.name }}/src/.django-app-template/admin/__init__.py-tpl
@@ -1,6 +1,7 @@
 from app.admin import ModelAdmin, admin
 
+
 __all__ = [
-    "admin",
     "ModelAdmin",
+    "admin",
 ]

--- a/{{ cookiecutter.name }}/src/.django-app-template/api/v1/urls.py-tpl
+++ b/{{ cookiecutter.name }}/src/.django-app-template/api/v1/urls.py-tpl
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from rest_framework.routers import SimpleRouter
 
+
 router = SimpleRouter()
 
 urlpatterns = [

--- a/{{ cookiecutter.name }}/src/.django-app-template/models/__init__.py-tpl
+++ b/{{ cookiecutter.name }}/src/.django-app-template/models/__init__.py-tpl
@@ -1,7 +1,8 @@
 from app.models import DefaultModel, TimestampedModel, models
 
+
 __all__ = [
-    "models",
     "DefaultModel",
     "TimestampedModel",
+    "models",
 ]

--- a/{{ cookiecutter.name }}/src/a12n/api/urls.py
+++ b/{{ cookiecutter.name }}/src/a12n/api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from a12n.api import views
 
+
 app_name = "a12n"
 
 urlpatterns = [

--- a/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/test_obtain_jwt_view.py
+++ b/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/test_obtain_jwt_view.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from axes.models import AccessAttempt
 
+
 pytestmark = pytest.mark.django_db
 
 

--- a/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/test_refresh_jwt_token.py
+++ b/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/test_refresh_jwt_token.py
@@ -3,6 +3,7 @@ from freezegun import freeze_time
 
 from a12n.utils import get_jwt
 
+
 pytestmark = [
     pytest.mark.django_db,
     pytest.mark.freeze_time("2049-01-05"),

--- a/{{ cookiecutter.name }}/src/app/admin/__init__.py
+++ b/{{ cookiecutter.name }}/src/app/admin/__init__.py
@@ -2,7 +2,8 @@ from django.contrib import admin
 
 from app.admin.model_admin import ModelAdmin
 
+
 __all__ = [
-    "admin",
     "ModelAdmin",
+    "admin",
 ]

--- a/{{ cookiecutter.name }}/src/app/api/viewsets.py
+++ b/{{ cookiecutter.name }}/src/app/api/viewsets.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Protocol, Type
+from typing import Any, Protocol
 
 from rest_framework import mixins, status
 from rest_framework.mixins import CreateModelMixin, UpdateModelMixin
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import BaseSerializer
 from rest_framework.viewsets import GenericViewSet
+
 
 __all__ = ["DefaultModelViewSet"]
 
@@ -101,8 +102,8 @@ class ResponseWithRetrieveSerializerMixin:
 
     def get_serializer_class(
         self: BaseGenericViewSet,
-        action: Optional[str] = None,
-    ) -> Type[BaseSerializer]:
+        action: str | None = None,
+    ) -> type[BaseSerializer]:
         if action is None:
             action = self.action  # type: ignore
 

--- a/{{ cookiecutter.name }}/src/app/api/viewsets.py
+++ b/{{ cookiecutter.name }}/src/app/api/viewsets.py
@@ -54,7 +54,7 @@ class DefaultUpdateModelMixin(UpdateModelMixin):
         if getattr(instance, "_prefetched_objects_cache", None):
             # If 'prefetch_related' has been applied to a queryset, we need to
             # forcibly invalidate the prefetch cache on the instance.
-            instance._prefetched_objects_cache = {}
+            instance._prefetched_objects_cache = {}  # noqa: SLF001
 
         return self.get_response(instance, status.HTTP_200_OK)
 

--- a/{{ cookiecutter.name }}/src/app/celery.py
+++ b/{{ cookiecutter.name }}/src/app/celery.py
@@ -3,6 +3,7 @@ import os
 from celery import Celery
 from django.conf import settings
 
+
 __all__ = ["celery"]
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")

--- a/{{ cookiecutter.name }}/src/app/conf/api.py
+++ b/{{ cookiecutter.name }}/src/app/conf/api.py
@@ -1,5 +1,6 @@
 from app.conf.environ import env
 
+
 # Django REST Framework
 # https://www.django-rest-framework.org/api-guide/settings/
 

--- a/{{ cookiecutter.name }}/src/app/conf/auth.py
+++ b/{{ cookiecutter.name }}/src/app/conf/auth.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from app.conf.environ import env
 
+
 AUTH_USER_MODEL = "users.User"
 AXES_ENABLED = env("AXES_ENABLED", cast=bool, default=True)
 

--- a/{{ cookiecutter.name }}/src/app/conf/boilerplate.py
+++ b/{{ cookiecutter.name }}/src/app/conf/boilerplate.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 ROOT_URLCONF = "app.urls"

--- a/{{ cookiecutter.name }}/src/app/conf/celery.py
+++ b/{{ cookiecutter.name }}/src/app/conf/celery.py
@@ -1,6 +1,7 @@
 from app.conf.environ import env
 from app.conf.timezone import TIME_ZONE
 
+
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", cast=str, default="redis://localhost:6379/0")
 CELERY_TASK_ALWAYS_EAGER = env("CELERY_TASK_ALWAYS_EAGER", cast=bool, default=env("DEBUG"))
 CELERY_TIMEZONE = TIME_ZONE

--- a/{{ cookiecutter.name }}/src/app/conf/db.py
+++ b/{{ cookiecutter.name }}/src/app/conf/db.py
@@ -3,6 +3,7 @@
 
 from app.conf.environ import env
 
+
 DATABASES = {
     # read os.environ["DATABASE_URL"] and raises ImproperlyConfigured exception if not found
     "default": env.db(),

--- a/{{ cookiecutter.name }}/src/app/conf/environ.py
+++ b/{{ cookiecutter.name }}/src/app/conf/environ.py
@@ -2,6 +2,7 @@ import environ  # type: ignore[import-untyped]
 
 from app.conf.boilerplate import BASE_DIR
 
+
 env = environ.Env(
     DEBUG=(bool, False),
     CI=(bool, False),

--- a/{{ cookiecutter.name }}/src/app/conf/http.py
+++ b/{{ cookiecutter.name }}/src/app/conf/http.py
@@ -1,5 +1,6 @@
 from app.conf.environ import env
 
+
 ALLOWED_HOSTS = ["*"]  # host validation is not necessary in 2020
 CSRF_TRUSTED_ORIGINS = [
     "http://your.app.origin",

--- a/{{ cookiecutter.name }}/src/app/conf/i18n.py
+++ b/{{ cookiecutter.name }}/src/app/conf/i18n.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from app.conf.boilerplate import BASE_DIR
 
+
 LANGUAGE_CODE = "ru"
 
 LOCALE_PATHS = [Path(BASE_DIR).parent / "locale"]

--- a/{{ cookiecutter.name }}/src/app/conf/media.py
+++ b/{{ cookiecutter.name }}/src/app/conf/media.py
@@ -1,4 +1,5 @@
 from app.conf.environ import env
 
+
 MEDIA_URL = "/media/"
 MEDIA_ROOT = env("MEDIA_ROOT", cast=str, default="media")

--- a/{{ cookiecutter.name }}/src/app/conf/sentry.py
+++ b/{{ cookiecutter.name }}/src/app/conf/sentry.py
@@ -1,5 +1,6 @@
 from app.conf.environ import env
 
+
 # Sentry
 # https://sentry.io/for/django/
 

--- a/{{ cookiecutter.name }}/src/app/conf/static.py
+++ b/{{ cookiecutter.name }}/src/app/conf/static.py
@@ -1,5 +1,6 @@
 from app.conf.environ import env
 
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.0/howto/static-files/
 

--- a/{{ cookiecutter.name }}/src/app/conf/storage.py
+++ b/{{ cookiecutter.name }}/src/app/conf/storage.py
@@ -1,5 +1,6 @@
 from app.conf.environ import env
 
+
 STORAGES = {
     "default": {
         "BACKEND": env(

--- a/{{ cookiecutter.name }}/src/app/factory.py
+++ b/{{ cookiecutter.name }}/src/app/factory.py
@@ -4,6 +4,7 @@ from faker import Faker
 from app.testing import register
 from app.testing.types import FactoryProtocol
 
+
 faker = Faker()
 
 

--- a/{{ cookiecutter.name }}/src/app/fixtures/__init__.py
+++ b/{{ cookiecutter.name }}/src/app/fixtures/__init__.py
@@ -1,6 +1,7 @@
 from app.fixtures.api import as_anon, as_user
 from app.fixtures.factory import factory
 
+
 __all__ = [
     "as_anon",
     "as_user",

--- a/{{ cookiecutter.name }}/src/app/middleware/real_ip.py
+++ b/{{ cookiecutter.name }}/src/app/middleware/real_ip.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 from django.http import HttpRequest, HttpResponse
 from ipware import get_client_ip

--- a/{{ cookiecutter.name }}/src/app/models.py
+++ b/{{ cookiecutter.name }}/src/app/models.py
@@ -4,10 +4,11 @@ from behaviors.behaviors import Timestamped  # type: ignore
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
+
 __all__ = [
-    "models",
     "DefaultModel",
     "TimestampedModel",
+    "models",
 ]
 
 

--- a/{{ cookiecutter.name }}/src/app/services.py
+++ b/{{ cookiecutter.name }}/src/app/services.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 
 class BaseService(metaclass=ABCMeta):

--- a/{{ cookiecutter.name }}/src/app/settings.py
+++ b/{{ cookiecutter.name }}/src/app/settings.py
@@ -6,6 +6,7 @@ from split_settings.tools import include
 
 from app.conf.environ import env
 
+
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env("SECRET_KEY")
 

--- a/{{ cookiecutter.name }}/src/app/testing/__init__.py
+++ b/{{ cookiecutter.name }}/src/app/testing/__init__.py
@@ -1,6 +1,7 @@
 from app.testing.api import ApiClient
 from app.testing.factory import FixtureFactory, register
 
+
 __all__ = [
     "ApiClient",
     "FixtureFactory",

--- a/{{ cookiecutter.name }}/src/app/testing/api.py
+++ b/{{ cookiecutter.name }}/src/app/testing/api.py
@@ -105,8 +105,7 @@ class ApiClient(DRFAPIClient):
 
         if self.is_json(response):
             return json.loads(content)
-        else:
-            return content
+        return content
 
     @staticmethod
     def is_json(response: Response) -> bool:

--- a/{{ cookiecutter.name }}/src/app/testing/factory.py
+++ b/{{ cookiecutter.name }}/src/app/testing/factory.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from functools import partial
-from typing import Callable
 
 from app.testing.mixer import mixer
 

--- a/{{ cookiecutter.name }}/src/app/testing/mixer.py
+++ b/{{ cookiecutter.name }}/src/app/testing/mixer.py
@@ -2,6 +2,7 @@ import uuid
 
 from mixer.backend.django import mixer
 
+
 __all__ = [
     "mixer",
 ]

--- a/{{ cookiecutter.name }}/src/app/tests/test_health.py
+++ b/{{ cookiecutter.name }}/src/app/tests/test_health.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 pytestmark = [
     pytest.mark.django_db,
     pytest.mark.filterwarnings("ignore:.*inspect.getargspec().*:DeprecationWarning"),

--- a/{{ cookiecutter.name }}/src/app/tests/test_remote_addr_midlleware.py
+++ b/{{ cookiecutter.name }}/src/app/tests/test_remote_addr_midlleware.py
@@ -3,14 +3,13 @@ from django.apps import apps
 
 from app.testing.api import ApiClient
 
+
 pytestmark = [pytest.mark.django_db]
 
 
 @pytest.fixture(autouse=True)
 def _require_users_app_installed(settings):
-    assert apps.is_installed(
-        "users"
-    ), """
+    assert apps.is_installed("users"), """
         Stock f213/django users app should be installed to run this test.
 
         Make sure to test app.middleware.real_ip.real_ip_middleware on your own, if you drop

--- a/{{ cookiecutter.name }}/src/app/urls/__init__.py
+++ b/{{ cookiecutter.name }}/src/app/urls/__init__.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 
+
 api = [
     path("v1/", include("app.urls.v1", namespace="v1")),
 ]

--- a/{{ cookiecutter.name }}/src/app/urls/v1.py
+++ b/{{ cookiecutter.name }}/src/app/urls/v1.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
+
 app_name = "api_v1"
 
 urlpatterns = [

--- a/{{ cookiecutter.name }}/src/app/wsgi.py
+++ b/{{ cookiecutter.name }}/src/app/wsgi.py
@@ -2,6 +2,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "app.settings")
 
 application = get_wsgi_application()

--- a/{{ cookiecutter.name }}/src/users/admin.py
+++ b/{{ cookiecutter.name }}/src/users/admin.py
@@ -3,4 +3,5 @@ from django.contrib.auth.admin import UserAdmin
 
 from users.models import User
 
+
 admin.site.register(User, UserAdmin)

--- a/{{ cookiecutter.name }}/src/users/api/urls.py
+++ b/{{ cookiecutter.name }}/src/users/api/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from users.api import viewsets
 
+
 app_name = "users"
 
 urlpatterns = [

--- a/{{ cookiecutter.name }}/src/users/fixtures.py
+++ b/{{ cookiecutter.name }}/src/users/fixtures.py
@@ -4,6 +4,7 @@ import pytest
 
 from users.models import User
 
+
 if TYPE_CHECKING:
     from app.testing.factory import FixtureFactory
 

--- a/{{ cookiecutter.name }}/src/users/models.py
+++ b/{{ cookiecutter.name }}/src/users/models.py
@@ -3,5 +3,5 @@ from typing import ClassVar
 from django.contrib.auth.models import AbstractUser, UserManager as _UserManager
 
 
-class User(AbstractUser):  # noqa
+class User(AbstractUser):
     objects: ClassVar[_UserManager] = _UserManager()

--- a/{{ cookiecutter.name }}/src/users/models.py
+++ b/{{ cookiecutter.name }}/src/users/models.py
@@ -1,7 +1,6 @@
 from typing import ClassVar
 
-from django.contrib.auth.models import AbstractUser
-from django.contrib.auth.models import UserManager as _UserManager
+from django.contrib.auth.models import AbstractUser, UserManager as _UserManager
 
 
 class User(AbstractUser):  # noqa

--- a/{{ cookiecutter.name }}/src/users/tests/test_password_hashing.py
+++ b/{{ cookiecutter.name }}/src/users/tests/test_password_hashing.py
@@ -4,6 +4,7 @@ import pytest
 
 from users.models import User
 
+
 pytestmark = [pytest.mark.django_db]
 
 

--- a/{{ cookiecutter.name }}/src/users/tests/test_whoami.py
+++ b/{{ cookiecutter.name }}/src/users/tests/test_whoami.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 pytestmark = [pytest.mark.django_db]
 
 


### PR DESCRIPTION
Issue https://github.com/fandsdev/django/issues/577

Добавил ruff, во многом вдохновлялся реализацией и конфигом из https://github.com/tough-dev-school/education-backend

Но тут есть несколько отличий:

1. Используются все правила UP (в т.ч. те, что форматируют старые варианты типа `List, Union, Optional` на актуальные варианты)
2. Используется отступ в 2 линии после блока импортов

В остальном всё то же самое.