### PR TITLE
Update README to stick with `poetry` v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@
 
 ## Installation
 
-You need python 3.11, [poetry](https://python-poetry.org) and [cookiecutter](https://www.cookiecutter.io/).
+You need python 3.11, [poetry<2](https://python-poetry.org) and [cookiecutter](https://www.cookiecutter.io/).
+The poetry sticks to poetry v1.x as the project plans to migrate to [uv](https://github.com/astral-sh/uv) package manager.
 
 We only support PostgreSQL as the database backend, so make sure it runs on `localhost:5432` before installing the project.
 
 ```bash
-pipx install poetry
+pipx install 'poetry<2'
 pipx install cookiecutter
 
 cookiecutter gh:fandsdev/django


### PR DESCRIPTION
Тут ничего не меняем, только явно обозначаю что нужен poetry <2

Зачем:
Код не совместим с poetry v2 (как минимум пропал ключ `--no-update` [отсюда](https://github.com/fandsdev/django/blob/fb2c4063ae845b3e4a281872583083deebc6ef1e/hooks/post_gen_project.sh#L5))

На версию 2 не обновляю: буду сразу делать миграцию на `uv`, с ним всё проще и меньше зависимостей.