### PR TITLE
Change password API

### DIFF
--- a/{{ cookiecutter.name }}/src/a12n/api/serializers.py
+++ b/{{ cookiecutter.name }}/src/a12n/api/serializers.py
@@ -1,6 +1,12 @@
 from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 
 class TokenObtainPairWithProperMessageSerializer(TokenObtainPairSerializer):
     default_error_messages = {"no_active_account": _("Invalid username or password.")}
+
+
+class PasswordChangeSerializer(serializers.Serializer):
+    old_password = serializers.CharField(max_length=128, style={"input_type": "password"})
+    new_password = serializers.CharField(max_length=128, style={"input_type": "password"})

--- a/{{ cookiecutter.name }}/src/a12n/api/urls.py
+++ b/{{ cookiecutter.name }}/src/a12n/api/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("token/", views.TokenObtainPairView.as_view(), name="auth_obtain_pair"),
     path("token/refresh/", views.TokenRefreshView.as_view(), name="auth_refresh"),
     path("logout/", jwt.TokenBlacklistView.as_view(), name="auth_logout"),
+    path("password/change/", views.PasswordChangeView.as_view(), name="auth_change_password"),
 ]

--- a/{{ cookiecutter.name }}/src/a12n/api/views.py
+++ b/{{ cookiecutter.name }}/src/a12n/api/views.py
@@ -1,6 +1,18 @@
+from django.contrib.auth.forms import PasswordChangeForm
+from django.utils import timezone
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework_simplejwt import views as jwt
+from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken, OutstandingToken
+from rest_framework_simplejwt.tokens import RefreshToken
 
+from a12n.api.serializers import PasswordChangeSerializer
 from a12n.api.throttling import AuthAnonRateThrottle
+from app.api.request import AuthenticatedRequest
+from users.models import User
 
 
 class TokenObtainPairView(jwt.TokenObtainPairView):
@@ -9,3 +21,47 @@ class TokenObtainPairView(jwt.TokenObtainPairView):
 
 class TokenRefreshView(jwt.TokenRefreshView):
     throttle_classes = [AuthAnonRateThrottle]
+
+
+class PasswordChangeView(APIView):
+    """Change user password, invalidate active user refresh tokens and return new token pair."""
+
+    throttle_classes = [AuthAnonRateThrottle]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        request=PasswordChangeSerializer,
+        responses=inline_serializer("PasswordChangeResponse", {"refresh": serializers.CharField(), "access": serializers.CharField()}),
+    )
+    def post(self, request: AuthenticatedRequest) -> Response:
+        serializer = PasswordChangeSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        self.validate_and_change_password(
+            user=request.user,
+            old_password=serializer.validated_data["old_password"],
+            new_password=serializer.validated_data["new_password"],
+        )
+        self.blacklist_active_user_tokens(request.user)
+
+        refresh = RefreshToken.for_user(request.user)
+        return Response({"refresh": str(refresh), "access": str(refresh.access_token)})
+
+    def validate_and_change_password(self, user: User, old_password: str, new_password: str) -> None:
+        """Change password with django's change password form or raise serializer aware field errors."""
+        form = PasswordChangeForm(user=user, data={"old_password": old_password, "new_password1": new_password, "new_password2": new_password})
+
+        if not form.is_valid():
+            if "new_password2" in form.errors:
+                form.errors["new_password"] = form.errors.pop("new_password2")  # to raise matched error fields matched serializer
+            raise serializers.ValidationError(form.errors)  # type: ignore[arg-type]
+
+        form.save()
+
+    def blacklist_active_user_tokens(self, user: User) -> None:
+        """Blacklist all active refresh tokens and force other user devices to relogin."""
+        active_tokens = OutstandingToken.objects.filter(user=user, blacklistedtoken__isnull=True, expires_at__gt=timezone.now())
+
+        BlacklistedToken.objects.bulk_create(
+            [BlacklistedToken(token=token, blacklisted_at=timezone.now()) for token in active_tokens],
+        )

--- a/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/conftest.py
+++ b/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/conftest.py
@@ -15,3 +15,17 @@ def user(factory):
 def initial_token_pair(user):
     refresh = RefreshToken.for_user(user)
     return {"refresh": str(refresh), "access": str(refresh.access_token)}
+
+
+@pytest.fixture
+def refresh_tokens(as_anon):
+    def _refresh_tokens(token, expected_status=200):
+        return as_anon.post(
+            "/api/v1/auth/token/refresh/",
+            {
+                "refresh": token,
+            },
+            expected_status=expected_status,
+        )
+
+    return _refresh_tokens

--- a/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/tests_change_password_view.py
+++ b/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/tests_change_password_view.py
@@ -1,0 +1,99 @@
+import pytest
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures("user"),
+]
+
+
+@pytest.fixture(autouse=True)
+def enable_en_i18n(settings):
+    """Enable English i18n for tests."""
+    settings.LANGUAGE_CODE = "en"
+    return settings
+
+
+@pytest.fixture
+def override_password_validators(settings):
+    """Set two password validators for tests."""
+    settings.AUTH_PASSWORD_VALIDATORS = [
+        {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator", "OPTIONS": {"min_length": 10}},
+        {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+        {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
+    ]
+    return settings
+
+
+@pytest.fixture
+def change_password(as_anon, initial_token_pair):
+    def _change(old_password, new_password, expected_status=200):
+        as_anon.credentials(HTTP_AUTHORIZATION=f"Bearer {initial_token_pair['access']}")
+
+        return as_anon.post(
+            "/api/v1/auth/password/change/",
+            {
+                "oldPassword": old_password,
+                "newPassword": new_password,
+            },
+            expected_status=expected_status,
+        )
+
+    return _change
+
+
+def test_password_actually_changed(change_password):
+    result = change_password("sn00pd0g", "kiTTy")
+
+    assert len(result["access"]) > 40
+    assert len(result["refresh"]) > 40
+
+
+def test_return_access_token_with_access_of_correct_user(change_password, as_anon, user):
+    access_token = change_password("sn00pd0g", "kiTTy")["access"]
+
+    as_anon.credentials(HTTP_AUTHORIZATION=f"Bearer {access_token}")
+    result = as_anon.get("/api/v1/users/me/")
+
+    assert result["id"] == user.id
+
+
+def test_changing_password_with_incorrect_old_password_fails(change_password):
+    result = change_password("50cent", "kiTTy", expected_status=400)
+
+    assert result["oldPassword"] == ["Your old password was entered incorrectly. Please enter it again."]
+
+
+@pytest.mark.usefixtures("override_password_validators")
+def test_changing_password_check_password_constraints(change_password):
+    result = change_password("sn00pd0g", "12345", expected_status=400)
+
+    assert "newPassword" in result
+    assert result["newPassword"] == [
+        "This password is too short. It must contain at least 10 characters.",
+        "This password is too common.",
+        "This password is entirely numeric.",
+    ]
+
+
+def test_changing_password_blacklists_all_active_user_tokens(change_password, refresh_tokens, user):
+    active_refresh_token = str(RefreshToken.for_user(user))
+    change_password("sn00pd0g", "kiTTy")
+
+    result = refresh_tokens(active_refresh_token, expected_status=401)
+
+    assert "blacklisted" in result["detail"]
+
+
+def test_change_password_anon_forbidden(as_anon):
+    result = as_anon.post(
+        "/api/v1/auth/password/change/",
+        {
+            "oldPassword": "sn00pd0g",
+            "newPassword": "kiTTy",
+        },
+        as_response=True,
+    )
+
+    assert result.status_code == 401

--- a/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/tests_refresh_jwt_view.py
+++ b/{{ cookiecutter.name }}/src/a12n/tests/jwt_views/tests_refresh_jwt_view.py
@@ -8,20 +8,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture
-def refresh_tokens(as_anon):
-    def _refresh_tokens(token, expected_status=200):
-        return as_anon.post(
-            "/api/v1/auth/token/refresh/",
-            {
-                "refresh": token,
-            },
-            expected_status=expected_status,
-        )
-
-    return _refresh_tokens
-
-
 def test_refresh_token_endpoint_token_pair(initial_token_pair, refresh_tokens):
     refreshed_token_pair = refresh_tokens(initial_token_pair["refresh"])
 

--- a/{{ cookiecutter.name }}/src/app/api/request.py
+++ b/{{ cookiecutter.name }}/src/app/api/request.py
@@ -1,0 +1,7 @@
+from rest_framework.request import Request
+
+from users.models import User
+
+
+class AuthenticatedRequest(Request):
+    user: User


### PR DESCRIPTION
API для смены пароля, для 

- #765 

Особенности:
1. Требуем старый пароль — чтоб одного access токены было недостаточно
2. Инвалидируем активные refresh токены — иначе можно обновлять бесконечно