### PR TITLE
Fix: remove `drf-jwt` from pyproject deps

### DIFF
--- a/{{ cookiecutter.name }}/pyproject.toml
+++ b/{{ cookiecutter.name }}/pyproject.toml
@@ -29,7 +29,6 @@ django-storages = "^1.14.4"
 djangorestframework = "^3.15.2"
 djangorestframework-camel-case = "^1.4.2"
 djangorestframework-simplejwt = {extras = ["crypto"], version = "^5.5.0"}
-drf-jwt = "^1.19.2"
 drf-spectacular = {extras = ["sidecar"], version = "^0.27.2"}
 pillow = "^10.1.0"
 psycopg2-binary = "^2.9.9"


### PR DESCRIPTION
Правлю баг: хз как оставил в зависимостях `drf-jwt`.
Ещё походу есть ошибки как разворачиваем проект: должен падать если зависимости `pyproject.toml` не соответствуют `poetry.lock`. Не пытаюсь поправить — должны переехать на uv и учесть там.