### PR TITLE
Dependabot: switch to uv package-ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: "/{{ cookiecutter.name }}"
   schedule:
     interval: daily


### PR DESCRIPTION
Обновляем настройки [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-) 