### PR TITLE
More precise types in BaseService

### DIFF
--- a/{{ cookiecutter.name }}/src/app/services.py
+++ b/{{ cookiecutter.name }}/src/app/services.py
@@ -40,5 +40,4 @@ class BaseService[T](metaclass=ABCMeta):
             validator()
 
     @abstractmethod
-    def act(self) -> T:
-        raise NotImplementedError("Please implement in the service class")
+    def act(self) -> T: ...

--- a/{{ cookiecutter.name }}/src/app/services.py
+++ b/{{ cookiecutter.name }}/src/app/services.py
@@ -1,9 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
-from typing import Any
 
 
-class BaseService(metaclass=ABCMeta):
+class BaseService[T](metaclass=ABCMeta):
     """This is a template of a a base service.
     All services in the app should follow this rules:
       * Input variables should be done at the __init__ phase
@@ -11,9 +10,9 @@ class BaseService(metaclass=ABCMeta):
 
     This is ok:
       @dataclass
-      class UserCreator(BaseService):
+      class UserCreator(BaseService[User]):
         first_name: str
-        last_name: Optional[str]
+        last_name: str | None
 
         def act(self) -> User:
           return User.objects.create(first_name=self.first_name, last_name=self.last_name)
@@ -22,13 +21,13 @@ class BaseService(metaclass=ABCMeta):
 
     This is not ok:
       class UserCreator:
-        def __call__(self, first_name: str, last_name: Optional[str]) -> User:
+        def __call__(self, first_name: str, last_name: str | None) -> User:
           return User.objects.create(first_name=self.first_name, last_name=self.last_name)
 
     For more implementation examples, check out https://github.com/tough-dev-school/education-backend/blob/master/src/apps/orders/services/order_course_changer.py
     """
 
-    def __call__(self) -> Any:
+    def __call__(self) -> T:
         self.validate()
         return self.act()
 
@@ -41,5 +40,5 @@ class BaseService(metaclass=ABCMeta):
             validator()
 
     @abstractmethod
-    def act(self) -> Any:
+    def act(self) -> T:
         raise NotImplementedError("Please implement in the service class")


### PR DESCRIPTION
Добавил точный вывод возвращаемого типа для вызовов сервисов вместо Any. (до этого всегда брался Any из базового класса)

Как-то лёг глаз на то, что не совсем корректная сигнатура у `__call__` и `act` у нас была, и решил поправить.
До этого проблем не было из-за всеядного `Any`, но и вывода типа из вызова SomeService()() не было нормального, а теперь вывод типов  будет точным.

Мелочь, а приятно.