### PR TITLE
Таски селери, выполняющиеся в основном треде падают с экспешенами

### DIFF
--- a/{{ cookiecutter.name }}/src/app/conf/celery.py
+++ b/{{ cookiecutter.name }}/src/app/conf/celery.py
@@ -4,6 +4,7 @@ from app.conf.timezone import TIME_ZONE
 
 CELERY_BROKER_URL = env("CELERY_BROKER_URL", cast=str, default="redis://localhost:6379/0")
 CELERY_TASK_ALWAYS_EAGER = env("CELERY_TASK_ALWAYS_EAGER", cast=bool, default=env("DEBUG"))
+CELERY_TASK_EAGER_PROPAGATES = True
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_ENABLE_UTC = False
 CELERY_TASK_ACKS_LATE = True


### PR DESCRIPTION
Когда выставлен `CELERY_ALWAYS_EAGER`, без этой настройки:

```py
@celery.task
def failing_task():
  raise RuntimeError

def test():
  failing_task.delay()

# OK
```

С этой настройкой:
```py
@celery.task
def failing_task():
  raise RuntimeError

def test():
  failing_task.delay()

# Exception: RuntimeError
```