### PR TITLE
Return back creating static directory on tests

### DIFF
--- a/{{ cookiecutter.name }}/Makefile
+++ b/{{ cookiecutter.name }}/Makefile
@@ -43,6 +43,7 @@ lint-yaml:
 	fi
 
 test:
+	@mkdir -p static  # be sure dir for static files exists
 	uv run pytest --dead-fixtures
 	uv run pytest --create-db --exitfirst --numprocesses ${SIMULTANEOUS_TEST_JOBS}
 


### PR DESCRIPTION
Return back creating `static` directory in tests

It's a rollback of changes that were made in PR #819 

I missed that without creating a directory for staticfiles, tests that run in CI for a new project produce warnings, and the easiest solution looks like creating the directory in tests.

<img width="2944" height="1144" alt="screen_2025-10-06T10 15 21Z@2x" src="https://github.com/user-attachments/assets/1cb74023-00ee-4e2c-bae4-d0440f9f6b37" />
