### PR TITLE
Remove DRF session authentication for debug mode

### DIFF
--- a/{{ cookiecutter.name }}/src/app/conf/api.py
+++ b/{{ cookiecutter.name }}/src/app/conf/api.py
@@ -32,11 +32,6 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "app.exceptions.app_service_exception_handler",
 }
 
-# Adding session auth and browsable API at the developer machine
-if env("DEBUG", cast=bool, default=False):
-    REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].append("rest_framework.authentication.SessionAuthentication")
-    REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"].append("djangorestframework_camel_case.render.CamelCaseBrowsableAPIRenderer")
-
 
 # Set up drf_spectacular, https://drf-spectacular.readthedocs.io/en/latest/settings.html
 SPECTACULAR_SETTINGS = {


### PR DESCRIPTION
# Проблема

Если у нас есть локальная джанга в докере на localhost:8000 и фронтенд на localhost:3000 часто происходит следующее:

1. Мы заходим в приложение
2. Мы заходим в админку
3. Мы возвращаемся в приложение и теперь все запросы отдают 403 ""CSRF Failed: Origin checking failed - https://localhost:3000/ does not match any trusted origins."
4. И это потому что кука csrf и sessionId от Django Admin теперь приклеены ко всем запросам фронта, даже если фронт работает через JWT в хедерах
5. Чтобы это пофиксить нужно вручную удалить их из памяти браузера, но в таком случае нас разлогинит из админки

# Решение

Со стороны бека: эта проблема возникает на открытых ручках (очень не удобно при авторизации). Происходит, потому что при DEBUG у нас DRF пытается авторизоваться так же и по сессиям.
Решил, что самое простое отказаться от сессий для DRF. Заодно удаляю и BrowsableAPIRenderer - кажется им давно уже никто не пользуется, а в агентский век, так уж точно.

[Артефакт в basecamp](https://app.basecamp.com/5104612/buckets/22530422/todos/10057670857#__recording_10078538588)