### PR TITLE
Fix app config base class being silently ignored

### DIFF
--- a/{{ cookiecutter.name }}/src/.django-app-template/apps.py-tpl
+++ b/{{ cookiecutter.name }}/src/.django-app-template/apps.py-tpl
@@ -2,4 +2,5 @@ from app.base_config import AppConfig
 
 
 class {{ camel_case_app_name }}Config(AppConfig):
+    default = True
     name = "{{ app_name }}"

--- a/{{ cookiecutter.name }}/src/app/base_config.py
+++ b/{{ cookiecutter.name }}/src/app/base_config.py
@@ -5,15 +5,19 @@ from django.apps.config import AppConfig as BaseAppConfig
 
 
 class AppConfig(BaseAppConfig):
-    """Default App configuration template. Import app.signals.handers.
+    """Default App configuration template. Imports app.signals.handlers.
 
-    We do not recomend you to use django signals at all.
+    We do not recommend you to use django signals at all.
     Check out https://lincolnloop.com/blog/django-anti-patterns-signals/ if
     you know nothing about that.
 
-    Allthough, if you wish to use signals, place handlers to the `signals/handlers.py`:
-    your code be automatically imported and used.
+    Although, if you wish to use signals, place handlers to the `signals/handlers.py`:
+    your code will be automatically imported and used.
     """
+
+    # Django's `apps.py` scan sees two configs — yours and this one, pulled in by your import.
+    # `False` here, `True` in your subclass: otherwise Django silently takes a plain AppConfig.
+    default = False
 
     def ready(self) -> None:
         """Import a module with handlers if it exists to avoid boilerplate code."""

--- a/{{ cookiecutter.name }}/src/app/conf/i18n.py
+++ b/{{ cookiecutter.name }}/src/app/conf/i18n.py
@@ -6,5 +6,3 @@ LANGUAGE_CODE = "ru"
 LOCALE_PATHS = [
     SRC_DIR / ".locale",
 ]
-
-USE_i18N = True

--- a/{{ cookiecutter.name }}/src/users/apps.py
+++ b/{{ cookiecutter.name }}/src/users/apps.py
@@ -5,5 +5,5 @@ from app.base_config import AppConfig as BaseAppConfig
 
 class AppConfig(BaseAppConfig):
     default = True
-    name = "app"
-    verbose_name = _("Application")
+    name = "users"
+    verbose_name = _("Users")


### PR DESCRIPTION
App configs from `manage.py startapp` have never been applied.
The generated subclass imports the base — Django finds two AppConfigs in `apps.py`, neither marked default, and quietly falls back to a plain one.
`default = False` on the base and `default = True` in the template fix it.