### PR TITLE
Generate OpenAPI 3.1 with split request schemas

### DIFF
--- a/{{ cookiecutter.name }}/src/app/conf/api.py
+++ b/{{ cookiecutter.name }}/src/app/conf/api.py
@@ -37,6 +37,8 @@ REST_FRAMEWORK = {
 SPECTACULAR_SETTINGS = {
     "TITLE": "Our fancy API",
     "DESCRIPTION": "So great, needs no docs",
+    "OAS_VERSION": "3.1.0",
+    "COMPONENT_SPLIT_REQUEST": True,  # request and response schemas rarely match: read-only fields, write-only fields, file uploads
     "SWAGGER_UI_DIST": "SIDECAR",
     "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
     "REDOC_DIST": "SIDECAR",


### PR DESCRIPTION
Request and response get separate components.

A single schema for both directions puts read-only fields into request types, and forces a file field to be a URL and an upload at the same time.
A client generated from that schema cannot type uploads at all.